### PR TITLE
v0.9.1 "I Want To Paint It Gray"

### DIFF
--- a/plugin_template/swinfo.json
+++ b/plugin_template/swinfo.json
@@ -5,7 +5,7 @@
     "name": "Orbital Survey",
     "description": "Scan celestial bodies from orbit.",
     "source": "https://github.com/Falki-git/OrbitalSurvey",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "version_check": "https://raw.githubusercontent.com/Falki-git/OrbitalSurvey/master/plugin_template/swinfo.json",
     "ksp2_version": {
         "min": "0.2.0",

--- a/src/OrbitalSurvey/UI/Controllers/MainGuiController.cs
+++ b/src/OrbitalSurvey/UI/Controllers/MainGuiController.cs
@@ -122,6 +122,12 @@ public class MainGuiController : MonoBehaviour
             {
                 OverlayManager.Instance.DrawOverlay(GetCurrentMapType());
             }
+            else if (Settings.ShowMapOverlayAlways.Value)
+            {
+                // this removes the uncompleted Map overlay on the body if the setting for ShowMapOverlayAlways is turned on
+                // if mapping is complete, we won't show the overlay - you can finally see the original texture in map view
+                OverlayManager.Instance.RemoveMap3dOverlayOnAllLoadedBodies();
+            }
         };
         
         BuildBodyDropdown();

--- a/src/OrbitalSurvey/Utilities/Settings.cs
+++ b/src/OrbitalSurvey/Utilities/Settings.cs
@@ -10,6 +10,7 @@ public static class Settings
     // "General" section
     public static ConfigEntry<float> TimeBetweenScans;
     public static ConfigEntry<bool> PlayUiSounds;
+    public static ConfigEntry<bool> ShowMapOverlayAlways;
     
     // "Maps" section
     public static ConfigEntry<bool> ShowRegionLegend;
@@ -47,6 +48,14 @@ public static class Settings
             "Play UI sounds",
             true,
             new ConfigDescription("If UI sounds will be played when clicked.")
+        );
+        
+        ShowMapOverlayAlways = Plugin.Config.Bind(
+            "General",
+            "Always show Map view overlay",
+            false,
+            new ConfigDescription("If toggled on Map view overlay texture will always be applied to every body in game.\n\n"
+                + "This effectively makes all bodies \"hidden\" in Map view until you scan them.")
         );
         
         // MAPS


### PR DESCRIPTION
![I want to paint it gray](https://github.com/Falki-git/OrbitalSurvey/assets/72734856/466f6aff-165f-4c05-b671-c10e75bc734e)

**Added a new config setting "Always show Map view overlay"** - requested by 123man

- When toggled, it will always display bodies with a hidden visual overlay in Map view. This effectively makes all bodies hidden/textureless until you scan them.
- This settings defaults to 'false' so you need to toggle it in Mod Settings if you want it. Main Menu -> Settings -> Mods